### PR TITLE
fix cli argument sanatization on mcl-init-factor

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -201,7 +201,7 @@ parseRefinementSteps = option auto
    <> help "Number of refinement steps. Default 1")
 
 parseInitCluster :: Parser Double
-parseInitCluster = (min 1.2 . abs) <$> option auto
+parseInitCluster = (max 1.2 . abs) <$> option auto
    (  long "mcl-init-factor"
    <> short 's'
    <> metavar "Double"


### PR DESCRIPTION
The MCL factor should be at minimum `1.2` (each gives the most gross clusterization) but a wrong logic on the argument sanitization making that value the maximum.